### PR TITLE
[SEB-28344] Use new color tokens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
 dependencies {
     implementation(project(":components"))
+    implementation(libs.kotlin.reflect)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/kotlin/se/seb/greencomponentsandroid/MainActivity.kt
+++ b/app/src/main/kotlin/se/seb/greencomponentsandroid/MainActivity.kt
@@ -13,22 +13,79 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import se.seb.gds.atoms.GdsSwitch
 import se.seb.gds.theme.GdsTheme
+import se.seb.gds.theme.colors.LegacyColors
+import se.seb.gds.tokens.darkModeColors
+import se.seb.gds.tokens.lightModeColors
+import se.seb.greencomponentsandroid.ui.ColorMapping
 import se.seb.greencomponentsandroid.ui.DesignLibraryScreen
+import kotlin.reflect.KProperty
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.typeOf
 
 class MainActivity : ComponentActivity() {
+
+    private lateinit var themeColors: List<Pair<String, ColorMapping>>
+    private lateinit var legacyThemeColors: List<Pair<String, ColorMapping>>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val lightColors = lightModeColors
+        val darkColors = darkModeColors
+        val lightThemeColorProperties = extractColorProperties(lightColors)
+        val darkThemeColorProperties = extractColorProperties(darkColors)
+        themeColors = combineColorLists(lightThemeColorProperties, darkThemeColorProperties)
+
+        val legacyLightColors = LegacyColors.defaultColors(false)
+        val legacyDarkColors = LegacyColors.defaultColors(true)
+        val legacyLightThemeColorProperties = extractColorProperties(legacyLightColors)
+        val legacyDarkThemeColorProperties = extractColorProperties(legacyDarkColors)
+        legacyThemeColors = combineColorLists(legacyLightThemeColorProperties, legacyDarkThemeColorProperties)
+
         setContent {
             GdsTheme {
-                DesignLibraryScreen()
+                DesignLibraryScreen(themeColors, legacyThemeColors)
             }
         }
     }
+}
+
+private inline fun <reified T : Any> extractColorProperties(instance: T): List<Pair<String, Color>> {
+    val colorProperties = mutableListOf<Pair<String, Color>>()
+    val kClass = T::class
+
+    kClass.memberProperties.forEach { property: KProperty<*> ->
+        if (property.returnType.isSubtypeOf(typeOf<Color>())) {
+            val colorValue = property.getter.call(instance) as Color
+            colorProperties.add(Pair(property.name, colorValue))
+        }
+    }
+
+    return colorProperties
+}
+
+private fun combineColorLists(
+    lightColors: List<Pair<String, Color>>,
+    darkColors: List<Pair<String, Color>>,
+): List<Pair<String, ColorMapping>> {
+    val lightColorMap = lightColors.toMap()
+    val darkColorMap = darkColors.toMap()
+
+    return (lightColorMap.keys + darkColorMap.keys)
+        .distinct()
+        .map { key ->
+            key to ColorMapping(
+                lightModeColor = lightColorMap[key] ?: Color.Transparent,
+                darkModeColor = darkColorMap[key] ?: Color.Transparent,
+            )
+        }
 }
 
 @Composable

--- a/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/ColorsScreen.kt
+++ b/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/ColorsScreen.kt
@@ -1,9 +1,85 @@
 package se.seb.greencomponentsandroid.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import se.seb.gds.theme.GdsTheme
 
+@Composable
+internal fun ColorsScreen(allColors: List<Pair<String, ColorMapping>>) {
+    var filterText by remember { mutableStateOf("") }
+    val listState = rememberLazyListState()
 
+    val filteredColors = remember(filterText, allColors) {
+        if (filterText.isBlank()) {
+            allColors
+        } else {
+            allColors.filter { (name, color) ->
+                name.contains(filterText, ignoreCase = true) ||
+                        color.lightModeValue.contains(filterText, ignoreCase = true) ||
+                        color.darkModeValue.contains(filterText, ignoreCase = true)
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+    ) {
+        OutlinedTextField(
+            value = filterText,
+            onValueChange = { filterText = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            label = { Text("Filter Colors") },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Done,
+            ),
+        )
+
+        LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(vertical = 16.dp),
+            verticalArrangement = spacedBy(16.dp),
+        ) {
+            items(
+                items = filteredColors,
+                key = { item -> item.first },
+            ) {
+                GallerySection(it.first) {
+                    ColorRow(it.second)
+                }
+            }
+        }
+    }
+}
 
 private fun Color.toHexString(): String {
     val argb = this.toArgb()
@@ -16,3 +92,53 @@ data class ColorMapping(
     val darkModeColor: Color,
     val darkModeValue: String = darkModeColor.toHexString(),
 )
+
+@Composable
+private fun ColorRow(colorMapping: ColorMapping) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = spacedBy(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .background(color = Color.LightGray, shape = RoundedCornerShape(2.dp))
+                .padding(2.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .background(color = colorMapping.lightModeColor),
+            )
+
+            Text(
+                text = colorMapping.lightModeValue,
+                color = Color.Black,
+                style = GdsTheme.typography.Caption2,
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .background(color = Color.Black, shape = RoundedCornerShape(2.dp))
+                .padding(2.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .background(color = colorMapping.darkModeColor),
+            )
+
+            Text(
+                text = colorMapping.darkModeValue,
+                color = Color.White,
+                style = GdsTheme.typography.Caption2,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/DesignLibraryScreen.kt
+++ b/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/DesignLibraryScreen.kt
@@ -53,8 +53,8 @@ internal fun DesignLibraryScreen(
         topBar = {
             CenterAlignedTopAppBar(
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = GdsTheme.colors.l1BackgroundSecondary,
-                    titleContentColor = GdsTheme.colors.l2ContentPrimary
+                    containerColor = GdsTheme.colors.l102,
+                    titleContentColor = GdsTheme.colors.contentContent01
                 ),
                 title = { Text(text = currentScreen.name, style = GdsTheme.typography.Headline) },
                 navigationIcon = {
@@ -63,15 +63,15 @@ internal fun DesignLibraryScreen(
                             Icon(
                                 Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "Back",
-                                tint = GdsTheme.colors.l2ContentPrimary
+                                tint = GdsTheme.colors.contentContent01
                             )
                         }
                     }
                 }
             )
         },
-        containerColor = GdsTheme.colors.l1BackgroundSecondary,
-        contentColor = GdsTheme.colors.l2ContentPrimary
+        containerColor = GdsTheme.colors.l102,
+        contentColor = GdsTheme.colors.contentContent01
     ) { paddingValues ->
         AnimatedContent(
             modifier = Modifier
@@ -105,9 +105,8 @@ internal fun DesignLibraryScreen(
                     currentScreen = it
                 }
 
-                LibraryScreen.COLORS -> {
-                    Box(modifier = Modifier.fillMaxSize())
-                }
+                LibraryScreen.COLORS -> ColorsScreen(allColors)
+                LibraryScreen.LEGACY_COLORS -> ColorsScreen(legacyColors)
 
                 LibraryScreen.FONTS -> FontsScreen(scrollState = scrollState)
                 LibraryScreen.SWITCHES -> SwitchesScreen(scrollState = scrollState)
@@ -133,6 +132,8 @@ private fun DesignLibrary(
     ) {
         GallerySection("Tokens") {
             ListItem("Colors") { onNavigateToSection(LibraryScreen.COLORS) }
+            HorizontalDivider()
+            ListItem("2016 Colors") { onNavigateToSection(LibraryScreen.LEGACY_COLORS) }
             HorizontalDivider()
             ListItem("Fonts") { onNavigateToSection(LibraryScreen.FONTS) }
         }

--- a/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/GallerySection.kt
+++ b/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/GallerySection.kt
@@ -46,6 +46,6 @@ internal fun ListItem(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(modifier = Modifier.weight(1f), text = title, color = GdsTheme.legacyColors.PrimaryText)
-        Icon(imageVector = SebIcons.RightChevron, contentDescription = null, tint = GdsTheme.colors.l3ContentPositive)
+        Icon(imageVector = SebIcons.RightChevron, contentDescription = null, tint = GdsTheme.colors.contentContent01)
     }
 }

--- a/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/LibraryScreen.kt
+++ b/app/src/main/kotlin/se/seb/greencomponentsandroid/ui/LibraryScreen.kt
@@ -3,6 +3,7 @@ package se.seb.greencomponentsandroid.ui
 enum class LibraryScreen {
     LIBRARY,
     COLORS,
+    LEGACY_COLORS,
     FONTS,
     SWITCHES,
     BUTTONS,

--- a/components/src/main/kotlin/se/seb/gds/atoms/GdsButton.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/GdsButton.kt
@@ -85,7 +85,7 @@ fun GdsButton(
                 Color.White
             }
         } else {
-            GdsTheme.colors.l3ContentTertiary
+            GdsTheme.colors.stateLightHover
         }
 
         CompositionLocalProvider(

--- a/components/src/main/kotlin/se/seb/gds/atoms/GdsButtonStyle.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/GdsButtonStyle.kt
@@ -122,20 +122,20 @@ object GdsButtonDefaults {
 
         @Composable
         fun primaryColors() = ButtonDefaults.buttonColors(
-            containerColor = GdsTheme.colors.l3BackgroundPrimary,
-            contentColor = GdsTheme.colors.l3ContentPrimary,
+            containerColor = GdsTheme.colors.l1Brand01,
+            contentColor = GdsTheme.colors.contentContent03,
         )
 
         @Composable
         fun secondaryColors() = ButtonDefaults.buttonColors(
-            containerColor = GdsTheme.colors.l3BackgroundSecondary,
-            contentColor = GdsTheme.colors.l3ContentTertiary
+            containerColor = GdsTheme.colors.l302,
+            contentColor = GdsTheme.colors.contentContent01
         )
 
         @Composable
         fun tertiaryColors() = ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
-            contentColor = GdsTheme.colors.l3ContentTertiary
+            contentColor = GdsTheme.colors.contentContent01
         )
     }
 

--- a/components/src/main/kotlin/se/seb/gds/atoms/GdsSwitch.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/GdsSwitch.kt
@@ -42,7 +42,7 @@ fun GdsSwitch(
     GdsTheme {
         CompositionLocalProvider(
             LocalRippleConfiguration provides RippleConfiguration(
-                color = style.colors.checkedTrackColor,
+                color = GdsTheme.colors.statePositivePressed,
                 rippleAlpha = RippleAlpha(0.16f, 0.1f, 0.08f, 0.1f)
             )
         ) {

--- a/components/src/main/kotlin/se/seb/gds/atoms/GdsSwitchStyle.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/GdsSwitchStyle.kt
@@ -61,11 +61,17 @@ object GdsSwitchDefaults {
     @Composable
     fun defaultColors(): SwitchColors {
         return SwitchDefaults.colors(
-            checkedThumbColor = Color.White,
-            checkedTrackColor = GdsTheme.colors.l3BackgroundPositive,
-            uncheckedThumbColor = GdsTheme.colors.l3BorderSecondary,
-            uncheckedTrackColor = GdsTheme.colors.l3BackgroundQuarternary,
-            checkedIconColor = GdsTheme.colors.l3BackgroundPositive
+            checkedThumbColor = GdsTheme.colors.l304,
+            checkedTrackColor = GdsTheme.colors.l3Positive01,
+            uncheckedThumbColor = GdsTheme.colors.contentContent02,
+            uncheckedTrackColor = GdsTheme.colors.l101,
+            uncheckedBorderColor = GdsTheme.colors.borderInteractive,
+            checkedIconColor = GdsTheme.colors.contentContentPositive01, // Does not look good in dark mode
+            disabledCheckedIconColor = GdsTheme.colors.contentContentDisabled01,
+            disabledCheckedTrackColor = GdsTheme.colors.l3Disabled02,
+            disabledCheckedThumbColor = GdsTheme.colors.l3Disabled03,
+            disabledUncheckedThumbColor = GdsTheme.colors.contentContentDisabled01,
+            disabledUncheckedTrackColor = GdsTheme.colors.l3Disabled03
         )
     }
 

--- a/components/src/main/kotlin/se/seb/gds/components/SwitchRow.kt
+++ b/components/src/main/kotlin/se/seb/gds/components/SwitchRow.kt
@@ -37,7 +37,7 @@ fun SwitchRow(
             .height(64.dp)
             .fillMaxWidth()
             .background(
-                color = GdsTheme.colors.l2BackgroundSecondary,
+                color = GdsTheme.colors.l201,
                 shape = RoundedCornerShape(12.dp)
             )
             .padding(16.dp),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ dokka = "2.0.0"
 vanniktech = "0.32.0"
 
 # SEB
-tokens = "0.0.2"
+tokens = "0.0.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +29,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 
 # SEB
 green-tokens = { group = "io.github.sebopensource", name = "android-tokens", version.ref = "tokens" }


### PR DESCRIPTION
This commit updates the components to use the new color tokens and introduces a new screen to display both current and legacy colors.

Changes include:
- Updating `GdsButtonStyle`, `GdsSwitch`, `GdsSwitchStyle`, and `SwitchRow` to utilize the new color tokens.
- Modifying `DesignLibraryScreen` and `GallerySection` to align with the new color tokens.
- Adding a `ColorsScreen` to visualize color tokens, including a filter functionality.
- Introducing a `LEGACY_COLORS` entry to `LibraryScreen` to display 2016 colors.
- Updating `MainActivity` to extract and prepare color data for the new `ColorsScreen`.
- Adding `kotlin-reflect` dependency.
- Incrementing `green-tokens` version.