### PR TITLE
[MCORE-320] Implement initial communication banner component

### DIFF
--- a/components/src/main/kotlin/se/seb/gds/atoms/cards/GdsCard.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/cards/GdsCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,6 +40,7 @@ fun GdsCard(
     containerColor: Color = GdsTheme.colors.L1.Neutral01,
     shape: Shape = GdsCardDefaults.shape,
     border: BorderStroke? = GdsCardDefaults.border,
+    elevation: CardElevation = GdsCardDefaults.elevation,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val cardModifier = Modifier
@@ -52,6 +54,7 @@ fun GdsCard(
             colors = CardDefaults.cardColors(containerColor = containerColor),
             shape = shape,
             border = border,
+            elevation = elevation,
             content = content,
         )
     } else {
@@ -60,6 +63,7 @@ fun GdsCard(
             colors = CardDefaults.cardColors(containerColor = containerColor),
             shape = shape,
             border = border,
+            elevation = elevation,
             content = content,
         )
     }

--- a/components/src/main/kotlin/se/seb/gds/atoms/cards/GdsCardDefaults.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/cards/GdsCardDefaults.kt
@@ -2,6 +2,8 @@ package se.seb.gds.atoms.cards
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
@@ -27,4 +29,7 @@ object GdsCardDefaults {
 
     val shape: Shape
         @Composable get() = RoundedCornerShape(GdsTheme.dimensions.radius.RadiusM)
+
+    val elevation: CardElevation
+        @Composable get() = CardDefaults.cardElevation()
 }

--- a/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBanner.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBanner.kt
@@ -1,0 +1,167 @@
+package se.seb.gds.atoms.communicationbanner
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.TopCenter
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import se.seb.gds.atoms.cards.GdsCard
+import se.seb.gds.common.GdsUiPreview
+import se.seb.gds.components.R
+import se.seb.gds.icons.GdsIcons
+import se.seb.gds.theme.GdsTheme
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun GdsCommunicationBanner(
+    heading: String,
+    body: String,
+    modifier: Modifier = Modifier,
+    bannerType: GdsCommunicationBannerType = GdsCommunicationBannerDefaults.bannerType,
+    elevation: CardElevation = GdsCommunicationBannerDefaults.elevation,
+    onDismiss: (() -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+) {
+    GdsCard(
+        modifier = modifier,
+        onClick = onClick,
+        containerColor = GdsCommunicationBannerDefaults.containerColor,
+        shape = GdsCommunicationBannerDefaults.shape,
+        elevation = elevation,
+        border = null,
+    ) {
+        Row(
+            modifier = Modifier.height(IntrinsicSize.Min),
+        ) {
+            Box(
+                contentAlignment = TopCenter,
+                modifier = Modifier
+                    .width(GdsTheme.dimensions.spacing.Space4Xl)
+                    .fillMaxHeight()
+                    .padding(
+                        top = GdsTheme.dimensions.spacing.Space2Xs,
+                        start = GdsTheme.dimensions.spacing.Space2Xs,
+                        bottom = GdsTheme.dimensions.spacing.Space2Xs,
+                    )
+                    .background(
+                        color = bannerType.bannerColor,
+                        shape = RoundedCornerShape(
+                            GdsTheme.dimensions.radius.RadiusXs,
+                        ),
+                    ),
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .padding(top = GdsTheme.dimensions.spacing.SpaceS)
+                        .size(GdsTheme.dimensions.spacing.SpaceXl),
+                    tint = bannerType.iconTint,
+                    imageVector = bannerType.icon,
+                    contentDescription = stringResource(R.string.common_action_close),
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1.0f)
+                    .padding(
+                        top = GdsTheme.dimensions.spacing.SpaceM,
+                        bottom = GdsTheme.dimensions.spacing.SpaceL,
+                        start = GdsTheme.dimensions.spacing.SpaceS,
+                        end = GdsTheme.dimensions.spacing.SpaceS,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(GdsTheme.dimensions.spacing.Space2Xs),
+            ) {
+                Text(
+                    text = heading,
+                    style = GdsTheme.typography.BodyMediumM,
+                    color = GdsCommunicationBannerDefaults.contentColor,
+                )
+                Text(
+                    text = body,
+                    style = GdsTheme.typography.BodyRegularS,
+                    color = GdsCommunicationBannerDefaults.contentColor,
+                )
+            }
+
+            if (onDismiss != null) {
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier
+                        .padding(
+                            top = GdsTheme.dimensions.spacing.SpaceXs,
+                            end = GdsTheme.dimensions.spacing.SpaceXs,
+                            start = GdsTheme.dimensions.spacing.Space0,
+                            bottom = GdsTheme.dimensions.spacing.Space0,
+                        )
+                        .size(GdsTheme.dimensions.spacing.SpaceXl),
+                ) {
+                    Icon(
+                        modifier = Modifier,
+                        tint = GdsCommunicationBannerDefaults.contentColor,
+                        imageVector = GdsIcons.Regular.CrossSmall,
+                        contentDescription = stringResource(R.string.common_action_close),
+                    )
+                }
+            } else {
+                Spacer(Modifier.size(GdsTheme.dimensions.spacing.SpaceM))
+            }
+        }
+    }
+}
+
+@GdsUiPreview
+@Composable
+private fun GdsCommunicationBannerPreview() {
+    GdsTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(GdsTheme.legacyColors.backgroundGrouped)
+                .padding(GdsTheme.dimensions.spacing.SpaceM),
+            verticalArrangement = Arrangement.spacedBy(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Information",
+                body = "This information card displays important details and optional actions for the user.",
+                bannerType = GdsCommunicationBannerType.Information,
+                onDismiss = {},
+            )
+            GdsCommunicationBanner(
+                heading = "Notice",
+                body = "This information card displays important details and optional actions for the user.",
+                bannerType = GdsCommunicationBannerType.Notice,
+                onDismiss = {},
+            )
+            GdsCommunicationBanner(
+                heading = "Warning",
+                body = "This information card displays important details and optional actions for the user.",
+                bannerType = GdsCommunicationBannerType.Warning,
+                onDismiss = {},
+            )
+            GdsCommunicationBanner(
+                heading = "Error",
+                body = "This information card displays important details and optional actions for the user.",
+                bannerType = GdsCommunicationBannerType.Error,
+                onDismiss = {},
+            )
+        }
+    }
+}

--- a/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBannerDefaults.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBannerDefaults.kt
@@ -1,0 +1,25 @@
+package se.seb.gds.atoms.communicationbanner
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import se.seb.gds.theme.GdsTheme
+
+object GdsCommunicationBannerDefaults {
+    val bannerType = GdsCommunicationBannerType.Information
+
+    val shape: Shape
+        @Composable get() = RoundedCornerShape(GdsTheme.dimensions.radius.RadiusS)
+
+    val containerColor: Color
+        @Composable get() = GdsTheme.legacyColors.secondaryGroupedBackgroundColor
+
+    val contentColor: Color
+        @Composable get() = GdsTheme.colors.Content.Neutral01
+
+    val elevation: CardElevation
+        @Composable get() = CardDefaults.elevatedCardElevation()
+}

--- a/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBannerType.kt
+++ b/components/src/main/kotlin/se/seb/gds/atoms/communicationbanner/GdsCommunicationBannerType.kt
@@ -1,0 +1,68 @@
+package se.seb.gds.atoms.communicationbanner
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import se.seb.gds.icons.GdsIcons
+import se.seb.gds.theme.GdsTheme
+
+/**
+ * Represents the visual style for a [GdsCommunicationBanner].
+ *
+ * Each style provides a specific icon, icon tint color, and banner background color
+ * to convey different types of messages (e.g., error, warning, success, info).
+ */
+enum class GdsCommunicationBannerType {
+    /**
+     * Error style - Used for critical messages or errors.
+     */
+    Error,
+
+    /**
+     * Warning style - Used for warning messages.
+     */
+    Warning,
+
+    /**
+     * Notice style - Used for success or confirmation messages.
+     */
+    Notice,
+
+    /**
+     * Information style - Used for informational messages.
+     */
+    Information,
+
+    ;
+
+    /**
+     * The icon to display in the banner.
+     */
+    val icon: ImageVector
+        @Composable get() = when (this) {
+            Error -> GdsIcons.Regular.TriangleExclamation
+            else -> GdsIcons.Regular.CircleInfo
+        }
+
+    /**
+     * The tint color for the icon.
+     */
+    val iconTint: Color
+        @Composable get() = when (this) {
+            Error -> GdsTheme.legacyColors.Red1
+            Warning -> GdsTheme.legacyColors.Yellow1
+            Notice -> GdsTheme.legacyColors.DarkBlue1
+            Information -> GdsTheme.legacyColors.PrimaryText
+        }
+
+    /**
+     * The background color for the banner indicator.
+     */
+    val bannerColor: Color
+        @Composable get() = when (this) {
+            Error -> GdsTheme.legacyColors.Red2
+            Warning -> GdsTheme.legacyColors.ErrorCard
+            Notice -> GdsTheme.legacyColors.LightBlue2
+            Information -> GdsTheme.legacyColors.TertiaryButtonBackground
+        }
+}

--- a/components/src/main/kotlin/se/seb/gds/preview/CommunicationBannerScreen.kt
+++ b/components/src/main/kotlin/se/seb/gds/preview/CommunicationBannerScreen.kt
@@ -1,0 +1,106 @@
+package se.seb.gds.preview
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import se.seb.gds.atoms.communicationbanner.GdsCommunicationBanner
+import se.seb.gds.atoms.communicationbanner.GdsCommunicationBannerType
+import se.seb.gds.components.SwitchRow
+import se.seb.gds.theme.GdsTheme
+
+@Composable
+internal fun CommunicationBannerScreen() {
+    var showInformation by rememberSaveable { mutableStateOf(true) }
+    var showNotice by rememberSaveable { mutableStateOf(true) }
+    var showWarning by rememberSaveable { mutableStateOf(true) }
+    var showError by rememberSaveable { mutableStateOf(true) }
+    var showCloseButton by rememberSaveable { mutableStateOf(true) }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(GdsTheme.dimensions.spacing.SpaceM),
+        verticalArrangement = Arrangement.spacedBy(GdsTheme.dimensions.spacing.SpaceM),
+    ) {
+        item(key = "toggle") {
+            SwitchRow(
+                title = "Show Close Button",
+                checked = showCloseButton,
+                onCheckedChanged = { showCloseButton = it },
+            )
+            HorizontalDivider(color = GdsTheme.colors.Border.Subtle01, thickness = 0.5.dp)
+        }
+
+        if (showInformation) {
+            item(key = "information") {
+                GdsCommunicationBanner(
+                    modifier = Modifier.animateItem(),
+                    heading = "Information",
+                    body = "This is an information banner that displays important details for the user.",
+                    bannerType = GdsCommunicationBannerType.Information,
+                    onDismiss = if (showCloseButton) {
+                        { showInformation = false }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+
+        if (showNotice) {
+            item(key = "notice") {
+                GdsCommunicationBanner(
+                    modifier = Modifier.animateItem(),
+                    heading = "Notice",
+                    body = "This is a notice banner that displays success or confirmation messages.",
+                    bannerType = GdsCommunicationBannerType.Notice,
+                    onDismiss = if (showCloseButton) {
+                        { showNotice = false }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+
+        if (showWarning) {
+            item(key = "warning") {
+                GdsCommunicationBanner(
+                    modifier = Modifier.animateItem(),
+                    heading = "Warning",
+                    body = "This is a warning banner that alerts users about potential issues.",
+                    bannerType = GdsCommunicationBannerType.Warning,
+                    onDismiss = if (showCloseButton) {
+                        { showWarning = false }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+
+        if (showError) {
+            item(key = "error") {
+                GdsCommunicationBanner(
+                    modifier = Modifier.animateItem(),
+                    heading = "Error",
+                    body = "This is an error banner that displays critical messages or errors.",
+                    bannerType = GdsCommunicationBannerType.Error,
+                    onDismiss = if (showCloseButton) {
+                        { showError = false }
+                    } else {
+                        null
+                    },
+                )
+            }
+        }
+    }
+}

--- a/components/src/main/kotlin/se/seb/gds/preview/DesignLibraryScreen.kt
+++ b/components/src/main/kotlin/se/seb/gds/preview/DesignLibraryScreen.kt
@@ -139,6 +139,8 @@ internal fun DesignLibraryScreen(
 
                     LibraryScreen.INFORMATION_CARD -> InformationCardScreen()
 
+                    LibraryScreen.COMMUNICATION_BANNER -> CommunicationBannerScreen()
+
                     else -> {}
                 }
             }
@@ -192,6 +194,8 @@ private fun DesignLibrary(
             }
             HorizontalDivider()
             ListItem("Information Card") { onNavigateToSection(LibraryScreen.INFORMATION_CARD) }
+            HorizontalDivider()
+            ListItem("Communication Banner") { onNavigateToSection(LibraryScreen.COMMUNICATION_BANNER) }
         }
     }
 }

--- a/components/src/main/kotlin/se/seb/gds/preview/LibraryScreen.kt
+++ b/components/src/main/kotlin/se/seb/gds/preview/LibraryScreen.kt
@@ -17,4 +17,5 @@ internal enum class LibraryScreen {
     LOADING_INDICATOR,
     DIALOGS,
     INFORMATION_CARD,
+    COMMUNICATION_BANNER,
 }

--- a/components/src/screenshotTest/kotlin/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshot.kt
+++ b/components/src/screenshotTest/kotlin/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshot.kt
@@ -1,0 +1,102 @@
+package se.seb.gds.atoms.communicationbanner
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.android.tools.screenshot.PreviewTest
+import se.seb.gds.common.GdsUiTestsPreview
+import se.seb.gds.theme.GdsTheme
+
+/**
+ * Screenshot tests for the [GdsCommunicationBanner] component.
+ */
+@PreviewTest
+@GdsUiTestsPreview
+@Composable
+private fun GdsCommunicationBannerInformationScreenshot() {
+    GdsTheme {
+        Column(
+            modifier = Modifier.padding(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Information",
+                body = "This is an information banner that displays important details for the user.",
+                bannerType = GdsCommunicationBannerType.Information,
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@PreviewTest
+@GdsUiTestsPreview
+@Composable
+private fun GdsCommunicationBannerNoticeScreenshot() {
+    GdsTheme {
+        Column(
+            modifier = Modifier.padding(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Notice",
+                body = "This is a notice banner that displays success or confirmation messages.",
+                bannerType = GdsCommunicationBannerType.Notice,
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@PreviewTest
+@GdsUiTestsPreview
+@Composable
+private fun GdsCommunicationBannerWarningScreenshot() {
+    GdsTheme {
+        Column(
+            modifier = Modifier.padding(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Warning",
+                body = "This is a warning banner that alerts users about potential issues.",
+                bannerType = GdsCommunicationBannerType.Warning,
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@PreviewTest
+@GdsUiTestsPreview
+@Composable
+private fun GdsCommunicationBannerErrorScreenshot() {
+    GdsTheme {
+        Column(
+            modifier = Modifier.padding(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Error",
+                body = "This is an error banner that displays critical messages or errors.",
+                bannerType = GdsCommunicationBannerType.Error,
+                onDismiss = {},
+            )
+        }
+    }
+}
+
+@PreviewTest
+@GdsUiTestsPreview
+@Composable
+private fun GdsCommunicationBannerWithoutCloseButtonScreenshot() {
+    GdsTheme {
+        Column(
+            modifier = Modifier.padding(GdsTheme.dimensions.spacing.SpaceM),
+        ) {
+            GdsCommunicationBanner(
+                heading = "Information",
+                body = "This banner does not have a close button.",
+                bannerType = GdsCommunicationBannerType.Information,
+                onDismiss = null,
+            )
+        }
+    }
+}

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerErrorScreenshot_Dark_15088e0a_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerErrorScreenshot_Dark_15088e0a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1e388dbf190791fb6a5f86d1008ca44145e44399e65538e342c2bd3ac2a4d2d
+size 18325

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerErrorScreenshot_Light_a39638cd_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerErrorScreenshot_Light_a39638cd_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f09892be829acda12af387e1bc3dbdface46ebf5912a54e4c41b11f3483fd468
+size 18365

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerInformationScreenshot_Dark_15088e0a_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerInformationScreenshot_Dark_15088e0a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e25c8db1fbb9bcea58b162c3694873580e11ed455a222653d600c7052ef202e
+size 21946

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerInformationScreenshot_Light_a39638cd_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerInformationScreenshot_Light_a39638cd_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b46182749a2605a8bec1618e4aadad74b3ebc628a24ecba8c20843af4a4e1a7
+size 21809

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerNoticeScreenshot_Dark_15088e0a_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerNoticeScreenshot_Dark_15088e0a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f7f82decc3df7b05d79823a7e731af9dfbc06b0f7dbda3be0145ee51ec32168
+size 21065

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerNoticeScreenshot_Light_a39638cd_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerNoticeScreenshot_Light_a39638cd_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca9eee47453200823f58b1e10d45ab1534d64919cb937c57026c0efab7cd3648
+size 21115

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWarningScreenshot_Dark_15088e0a_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWarningScreenshot_Dark_15088e0a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62a3d5ee71b6044fa1093a366c059daf744e6d725eba7f7a8d799f988547c513
+size 20431

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWarningScreenshot_Light_a39638cd_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWarningScreenshot_Light_a39638cd_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:205e370ccaa4d9cb49155cfdeca49dd4d470bcb8d3abbc8ecedf1b19edce3404
+size 20447

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWithoutCloseButtonScreenshot_Dark_15088e0a_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWithoutCloseButtonScreenshot_Dark_15088e0a_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d6e896ba06d448f58e68ca96b4798254ed2817b8a9eb8771bfdea6ca7406cc
+size 15214

--- a/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWithoutCloseButtonScreenshot_Light_a39638cd_0.png
+++ b/components/src/screenshotTestDebug/reference/se/seb/gds/atoms/communicationbanner/CommunicationBannerScreenshotKt/GdsCommunicationBannerWithoutCloseButtonScreenshot_Light_a39638cd_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62711df3f81069dee28a9d8c2c1dc96397de820255c8698d32b29018998cb49b
+size 15273

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=io.github.sebopensource
 POM_ARTIFACT_ID=components
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 
 POM_NAME=Green Design System for Android
 POM_DESCRIPTION=The official Android implementation of SEB's Green Design System.


### PR DESCRIPTION
## Description
Implement initial communication banner component. We are adding this component as a first version, we don't have the final design yet with us. Because of that it uses some of the legacy colors and styles. Once we have a final design we will update the component and documentation.

Design - https://www.figma.com/design/BPKrpgOtwDxkIt6gu0vgDY/Communication-areas?node-id=2277-38023&t=O1kS2PWKjGevTr1g-0

###Screenshot
[Screen_recording_20260402_172558.webm](https://github.com/user-attachments/assets/0b5833e5-37c3-46f3-9450-3db05acc1f2d)



